### PR TITLE
Fix 'package' link, add md report format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,41 @@
 # https://dart.dev/guides/libraries/private-files
 # Created by `dart pub`
 .dart_tool/
-.DS_Store
+.packages
+.pub/
+
+# Dependency lock file (for libraries)
+pubspec.lock
+
+# Build outputs
+build/
+
+# Flutter specific
+.flutter-plugins
+.flutter-plugins-dependencies
+.flutter-version
+
+# iOS
+ios/Pods/
+ios/.symlinks/
+ios/Flutter/Flutter.framework/
+ios/Flutter/Flutter.podspec
+ios/Runner.xcworkspace/
+*.xcworkspace
+*.xcconfig
+
+# Xcode
+*.xcuserstate
+
+# Android
+android/.gradle/
+android/app/build/
+android/local.properties
+
+# IDEs and editors
+.idea/
+.vscode/
+*.iml
+
+# Misc
+*.log

--- a/lib/src/analyzers/usage_analyzer.dart
+++ b/lib/src/analyzers/usage_analyzer.dart
@@ -14,6 +14,17 @@ void findUsages({
   required bool showProgress,
   required bool analyzeFunctions,
 }) {
+  // Reset usage counts before scanning all files
+  for (final classInfo in classes.values) {
+    classInfo.internalUsageCount = 0;
+    classInfo.externalUsages.clear();
+  }
+  if (analyzeFunctions) {
+    for (final functionInfo in functions.values) {
+      functionInfo.internalUsageCount = 0;
+      functionInfo.externalUsages.clear();
+    }
+  }
   final dartFiles = getDartFiles(dir);
 
   ProgressBar? progressBar;
@@ -30,7 +41,7 @@ void findUsages({
       final content = File(filePath).readAsStringSync();
 
       // Analyze class usages
-      analyzeClassUsages(content, filePath, classes);
+      analyzeClassUsages(content, filePath, classes, reset: false);
 
       // Analyze function usages
       if (analyzeFunctions) {

--- a/lib/src/usage/class_uages.dart
+++ b/lib/src/usage/class_uages.dart
@@ -2,11 +2,14 @@ import 'package:dead_code_analyzer/src/model/class_info.dart';
 import 'package:dead_code_analyzer/src/model/import_info.dart';
 
 void analyzeClassUsages(
-    String content, String filePath, Map<String, ClassInfo> classes) {
-  // Reset usage counts for all classes
-  for (final classInfo in classes.values) {
-    classInfo.internalUsageCount = 0;
-    classInfo.externalUsages.clear();
+    String content, String filePath, Map<String, ClassInfo> classes,
+    {bool reset = true}) {
+  if (reset) {
+    // Reset usage counts for all classes
+    for (final classInfo in classes.values) {
+      classInfo.internalUsageCount = 0;
+      classInfo.externalUsages.clear();
+    }
   }
   // Parse all imports in the current file
   final imports = parseImports(content);

--- a/test/class_uses/class_used_test.dart
+++ b/test/class_uses/class_used_test.dart
@@ -241,6 +241,18 @@ void main() {
       expect(imports[0].hiddenClasses, ['MyWidget', 'OtherClass']);
       expect(imports[0].shownClasses, isEmpty);
     });
+    test('should parse package import', () {
+      final content = '''
+        import 'package:translator/domain/repositories/subtitle_repository.dart';
+      ''';
+      final imports = parseImports(content);
+      expect(imports.length, 1);
+      expect(imports[0].path,
+          'package:translator/domain/repositories/subtitle_repository.dart');
+      expect(imports[0].asAlias, isNull);
+      expect(imports[0].shownClasses, isEmpty);
+      expect(imports[0].hiddenClasses, isEmpty);
+    });
   });
 
   group('isClassAccessibleInFile', () {
@@ -284,6 +296,33 @@ void main() {
           isClassAccessibleInFile(
               'MyWidget', '/path/to/my_widget.dart', imports),
           isFalse);
+    });
+    test('should return true for accessible class with package import', () {
+      final imports = [
+        ImportInfo(
+            path:
+                'package:translator/domain/repositories/subtitle_repository.dart'),
+      ];
+      final classPath =
+          '/Users/developer/project/lib/domain/repositories/subtitle_repository.dart';
+      expect(
+        isClassAccessibleInFile('SubtitleRepository', classPath, imports),
+        isTrue,
+      );
+    });
+
+    test('should return false for non-matching package import', () {
+      final imports = [
+        ImportInfo(
+            path:
+                'package:translator/domain/repositories/other_repository.dart'),
+      ];
+      final classPath =
+          '/Users/developer/project/lib/domain/repositories/subtitle_repository.dart';
+      expect(
+        isClassAccessibleInFile('SubtitleRepository', classPath, imports),
+        isFalse,
+      );
     });
   });
 


### PR DESCRIPTION
New report format

# Flutter Code Usage Analysis - 2025-07-09_21-05-16
==================================================
This report lists classes and functions (if analyzed) by usage type.Entry-point entities (@pragma("vm:entry-point")) and state classes are reported separately.Empty prebuilt Flutter functions (e.g., build, initState) are listed separately.File paths are relative to the lib/ directory or project root.

![❌ Unused](https://img.shields.io/badge/Unused_12-red) ![🏠 Internal](https://img.shields.io/badge/Internal_181-yellow) ![🌐 External](https://img.shields.io/badge/External_40-blue) ![✅ Both](https://img.shields.io/badge/Both_142-brightgreen)

## 🔖 Summary
| Category                          | Count |
|:----------------------------------|:-----:|
| ❌ Unused Classes                 | 12 |
| 🏠 Classes Used Only Internally   | 181 |
| 🌐 Classes Used Only Externally   | 40 |
| ✅ Classes Used Both              | 142 |

Class Analysis
==============================
<details>
<summary>Unused Classes (12)</summary>

---
| Class | Internal | External | Total |
|:---|:---:|:---:|:---:|
| 📄 [ProjectTaskTypeExtension](<file:///D:/lib/data/models/project_task_type.dart#L11>) | 0 | 0 | 0 |

</details>

<details>
<summary>Commented Classes (0)</summary>

---
No commented_classes found.

</details>

<details>
<summary>Classes Used Only Internally (156)</summary>

---
| Class | Internal | External | Total |
|:---|:---:|:---:|:---:|
| 📄 [StyledContainer](<file:///D:/styled_container.dart#L5>) | 1 | 0 | 1 |

</details>

<details>
<summary>Classes Used Only Externally (31)</summary>

---
| Class | Internal | External | Total |
|:---|:---:|:---:|:---:|
| 📄 [PlayerServiceImpl](<file:///D:/implementations/player_service_impl.dart#L8>) | 0 | 1 | 1 |

</details>

<details>
<summary>Classes Used Both Internally and Externally (121)</summary>

---
| Class | Internal | External | Total |
|:---|:---:|:---:|:---:|
| 📄 [LogService](<file:///D:/log_service.dart#L8>) | 1 | 304 | 305 |

</details>

<details>
<summary>Mixing Classes (8)</summary>

---
| Class | Internal | External | Total |
|:---|:---:|:---:|:---:|
| 📄 [NotificationWidget](<file:///D:/widget.dart#L15>) | 3 | 76 | 79 |

</details>

<details>
<summary>Enum Classes (36)</summary>

---
| Class | Internal | External | Total |
|:---|:---:|:---:|:---:|
| 📄 [LimitationType](<file:///D:/validator.dart#L484>) | 2 | 0 | 2 |


</details>

<details>
<summary>Extension Classes (1)</summary>

---
| Class | Internal | External | Total |
|:---|:---:|:---:|:---:|
| 📄 [EntryFactory](<file:///entry.dart#L94>) | 0 | 1 | 1 |

</details>

<details>
<summary>Typedef Classes (0)</summary>

---
No typedef_classes found.

</details>

<details>
<summary>State Classes (10)</summary>

---
| Class | Internal | External | Total |
|:---|:---:|:---:|:---:|
| 📄 [_Test](<file:///D:/widget.dart#L46>) | 1 | 0 | 1 |


</details>

<details>
<summary>@pragma Classes: Hints for Dart compiler/runtime optimizations. (0)</summary>

---
No entry_point_classes found.

</details>

## 📋 Summary
| Metric | Count | Percent |
|:-----------------------------|------:|--------:|
| 🧮 **Total classes**          | 375 | 100% |
| ❌ Unused classes             | 12 | 3.2% |
| 🏠 Internal only              | 156 | 41.6% |
| 🌐 External only              | 31 | 8.3% |
| ✅ Both internal & external   | 121 | 32.3% |
| 🧩 Mixin classes              | 8 | 2.1% |
| 🔢 Enum classes               | 36 | 9.6% |
| 🧩 Extension classes          | 1 | 0.3% |
| 🧬 State classes              | 10 | 2.7% |
| 🚩 Entry-point classes        | 0 | 0.0% |

## 📊 Class Usage Distribution (ASCII)
| Category      | Count |
|:------------- |:------|
| ❌ Unused | █ 12 |
| 🏠 Internal | ██████████████████████████████ 181 |
| 🌐 External | ██████ 40 |
| ✅ Both | ███████████████████████ 142 |

## 📄 File Size Distribution (ASCII)
| File Size      | Count |
|:-------------- |:------|
| <50 lines | ██████████████████████████████ 84 |
| 50-200 lines | ████████████████████████████ 81 |
| 201-500 lines | █████████████████████ 60 |
| 501-1000 lines | ██████████ 30 |
| >1000 lines | █ 4 |

